### PR TITLE
Rename column "modified" to "revised" so it's the same as archive

### DIFF
--- a/cnxauthoring/models.py
+++ b/cnxauthoring/models.py
@@ -103,7 +103,7 @@ class Document:
 
     def __init__(self, title, id=None,
                  content=None, abstract=None,
-                 created=None, modified=None,
+                 created=None, revised=None,
                  license=LICENSE_PARAMETER_MARKER,
                  language=None, derived_from=None, submitter=None):
         self.title = title
@@ -113,7 +113,7 @@ class Document:
         self.abstract = abstract is None and '' or abstract
         now = datetime.datetime.now(tz=TZINFO)
         self.created = created is None and now or created
-        self.modified = modified is None and now or modified
+        self.revised = revised is None and now or revised
         # license is a reserved name that will never be None.
         if license is LICENSE_PARAMETER_MARKER:
             self.license = DEFAULT_LICENSE
@@ -134,7 +134,7 @@ class Document:
         c = self.__dict__.copy()
         c['id'] = str(c['id'])
         c['created'] = c['created'].isoformat()
-        c['modified'] = c['modified'].isoformat()
+        c['revised'] = c['revised'].isoformat()
         c['license'] = c['license'].__dict__.copy()
         c['media_type'] = self.mediatype
         return c
@@ -229,6 +229,6 @@ def derive_content(request, **kwargs):
     utils.change_dict_keys(document, utils.camelcase_to_underscore)
     document['title'] = u'Copy of {}'.format(document['title'])
     document['created'] = None
-    document['modified'] = None
+    document['revised'] = None
     document['license'] = {'url': DEFAULT_LICENSE.url}
     return document

--- a/cnxauthoring/modifiers.py
+++ b/cnxauthoring/modifiers.py
@@ -22,7 +22,7 @@ def json_document_adapter(obj, request):
         'id': obj.id,
         'title': obj.title,
         'created': obj.created,
-        'modified': obj.modified,
+        'revised': obj.revised,
         }
 
 

--- a/cnxauthoring/schemata.py
+++ b/cnxauthoring/schemata.py
@@ -60,7 +60,7 @@ class DocumentSchema(colander.MappingSchema):
         colander.DateTime(default_tzinfo=TZINFO),
         missing=deferred_datetime_missing,
         )
-    modified = colander.SchemaNode(
+    revised = colander.SchemaNode(
         colander.DateTime(default_tzinfo=TZINFO),
         missing=deferred_datetime_missing,
         )

--- a/cnxauthoring/storage/sql/add-document.sql
+++ b/cnxauthoring/storage/sql/add-document.sql
@@ -8,6 +8,6 @@
 -- arguments: hash:string; mediatype:string, data:bytea
 
 INSERT INTO document (license, language, created, abstract, media_type,
-                      title, modified, content, derived_from, submitter, id) 
+                      title, revised, content, derived_from, submitter, id) 
         VALUES(%(license)s, %(language)s, %(created)s, %(abstract)s, %(media_type)s,
-               %(title)s, %(modified)s, %(content)s, %(derived_from)s, %(submitter)s, %(id)s);
+               %(title)s, %(revised)s, %(content)s, %(derived_from)s, %(submitter)s, %(id)s);

--- a/cnxauthoring/storage/sql/schema/document.sql
+++ b/cnxauthoring/storage/sql/schema/document.sql
@@ -1,7 +1,7 @@
 CREATE TABLE document ( id              uuid primary key, 
                         title           text not null,
                         created         timestamptz not null,
-                        modified        timestamptz not null,
+                        revised         timestamptz not null,
                         license         text not null,
                         language        text not null,
                         media_type      text not null,

--- a/cnxauthoring/storage/sql/update-document.sql
+++ b/cnxauthoring/storage/sql/update-document.sql
@@ -10,7 +10,7 @@
 UPDATE document 
         SET license = %(license)s, language = %(language)s, 
             created = %(created)s, abstract = %(abstract)s,
-            title = %(title)s, modified = %(modified)s, 
+            title = %(title)s, revised = %(revised)s, 
             content = %(content)s, derived_from = %(derived_from)s,
             submitter = %(submitter)s
 WHERE id  = %(id)s

--- a/cnxauthoring/tests/test_functional.py
+++ b/cnxauthoring/tests/test_functional.py
@@ -220,7 +220,7 @@ class FunctionalTests(unittest.TestCase):
                 json.dumps({
                     'title': 'My New Document',
                     'created': u'2014-03-13T15:21:15',
-                    'modified': u'2014-03-13T15:21:15',
+                    'revised': u'2014-03-13T15:21:15',
                     }),
                 status=201)
         put_result = json.loads(response.body.decode('utf-8'))
@@ -239,7 +239,7 @@ class FunctionalTests(unittest.TestCase):
                 u'url': u'http://creativecommons.org/licenses/by/4.0/',
                 u'version': u'4.0',
                 },
-            u'modified': get_result['modified'],
+            u'revised': get_result['revised'],
             u'mediaType': u'application/vnd.org.cnx.module',
             u'language': u'en',
             u'submitter': u'me',
@@ -410,7 +410,7 @@ class FunctionalTests(unittest.TestCase):
         self.assertTrue(u'Lav en madplan for den kommende uge'
                 in result.pop('content'))
         self.assertFalse('2011-10-05' in result.pop('created'))
-        self.assertTrue(result.pop('modified') is not None)
+        self.assertTrue(result.pop('revised') is not None)
         self.assertEqual(result, {
             u'submitter': FunctionalTests.profile['username'],
             u'id': result['id'],
@@ -437,7 +437,7 @@ class FunctionalTests(unittest.TestCase):
         self.assertTrue(u'Lav en madplan for den kommende uge'
                 in result.pop('content'))
         self.assertTrue(result.pop('created') is not None)
-        self.assertTrue(result.pop('modified') is not None)
+        self.assertTrue(result.pop('revised') is not None)
         self.assertEqual(result, {
             u'submitter': FunctionalTests.profile['username'],
             u'id': result['id'],
@@ -476,7 +476,7 @@ class FunctionalTests(unittest.TestCase):
         result = json.loads(response.body.decode('utf-8'))
         self.maxDiff = None
         self.assertFalse('2011-10-12' in result.pop('created'))
-        self.assertTrue(result.pop('modified') is not None)
+        self.assertTrue(result.pop('revised') is not None)
         self.assertEqual(result, {
             u'submitter': FunctionalTests.profile['username'],
             u'id': result['id'],
@@ -520,7 +520,7 @@ class FunctionalTests(unittest.TestCase):
                 '/contents/{}@draft.json'.format(result['id']), status=200)
         result = json.loads(response.body.decode('utf-8'))
         self.assertTrue(result.pop('created') is not None)
-        self.assertTrue(result.pop('modified') is not None)
+        self.assertTrue(result.pop('revised') is not None)
         self.assertEqual(result, {
             u'submitter': FunctionalTests.profile['username'],
             u'id': result['id'],
@@ -561,7 +561,7 @@ class FunctionalTests(unittest.TestCase):
             'title': u"Turning DNA through resonance",
             'abstract': u"Theories on turning DNA structures",
             'created': u'2014-03-13T15:21:15.677617',
-            'modified': u'2014-03-13T15:21:15.677617',
+            'revised': u'2014-03-13T15:21:15.677617',
             'license': {'url': DEFAULT_LICENSE.url},
             'language': u'en',
             'content': u"Ding dong the switch is flipped.",
@@ -576,8 +576,8 @@ class FunctionalTests(unittest.TestCase):
         self.assertEqual(license['url'], post_data['license']['url'])
         created = result.pop('created')
         self.assertTrue(created.startswith('2014-03-13T15:21:15.677617'))
-        modified = result.pop('modified')
-        self.assertTrue(modified.startswith('2014-03-13T15:21:15.677617'))
+        revised = result.pop('revised')
+        self.assertTrue(revised.startswith('2014-03-13T15:21:15.677617'))
         self.assertEqual(result, {
             u'submitter': FunctionalTests.profile['username'],
             u'id': result['id'],
@@ -634,7 +634,7 @@ class FunctionalTests(unittest.TestCase):
                 '/contents/{}@draft.json'.format(book['id']), status=200)
         result = json.loads(response.body.decode('utf-8'))
         self.assertTrue(result.pop('created') is not None)
-        self.assertTrue(result.pop('modified') is not None)
+        self.assertTrue(result.pop('revised') is not None)
         self.assertEqual(result, {
             u'id': book['id'],
             u'title': u'Book',
@@ -730,7 +730,7 @@ class FunctionalTests(unittest.TestCase):
                 json.dumps(update_data), status=200)
         result = json.loads(response.body.decode('utf-8'))
         self.assertTrue(result.pop('created') is not None)
-        self.assertTrue(result.pop('modified') is not None)
+        self.assertTrue(result.pop('revised') is not None)
         self.assertEqual(result, {
             u'submitter': FunctionalTests.profile['username'],
             u'id': result['id'],
@@ -761,7 +761,7 @@ class FunctionalTests(unittest.TestCase):
                 status=200)
         result = json.loads(response.body.decode('utf-8'))
         self.assertTrue(result.pop('created') is not None)
-        self.assertTrue(result.pop('modified') is not None)
+        self.assertTrue(result.pop('revised') is not None)
         self.assertEqual(result, {
             u'submitter': FunctionalTests.profile['username'],
             u'id': result['id'],
@@ -878,7 +878,7 @@ class FunctionalTests(unittest.TestCase):
             'title': u"Turning DNA through resonance",
             'abstract': u"Theories on turning DNA structures",
             'created': u'2014-03-13T15:21:15.677617',
-            'modified': u'2014-03-13T15:21:15.677617',
+            'revised': u'2014-03-13T15:21:15.677617',
             'license': {'url': DEFAULT_LICENSE.url},
             'language': u'en',
             'contents': u"Ding dong the switch is flipped.",

--- a/cnxauthoring/tests/test_modifiers.py
+++ b/cnxauthoring/tests/test_modifiers.py
@@ -43,7 +43,7 @@ class ModelJSONRendering(unittest.TestCase):
             'id': str(id),
             'title': title,
             'created': document.created.isoformat(),
-            'modified': document.modified.isoformat(),
+            'revised': document.revised.isoformat(),
             'mediaType': Document.mediatype,
             'language': 'en',
             'version': 'draft',

--- a/cnxauthoring/tests/test_views.py
+++ b/cnxauthoring/tests/test_views.py
@@ -125,7 +125,7 @@ class ViewsTests(unittest.TestCase):
             'title': "Turning DNA through resonance",
             'abstract': "Theories on turning DNA structures",
             'created': datetime.datetime.now().isoformat(),
-            'modified': datetime.datetime.now().isoformat(),
+            'revised': datetime.datetime.now().isoformat(),
             'license': {'url': DEFAULT_LICENSE.url},
             'language': 'en',
             'content': "Ding dong the switch is flipped.",
@@ -157,7 +157,7 @@ class ViewsTests(unittest.TestCase):
         self.assertEqual(returned_document, self.document)
         self.assertEqual(returned_document.title, post_data['title'])
         self.assertEqual(returned_document.abstract, post_data['abstract'])
-        # TODO Test created and modified dates.
+        # TODO Test created and revised dates.
         self.assertEqual(returned_document.license.url, DEFAULT_LICENSE.url)
         self.assertEqual(returned_document.language, post_data['language'])
         self.assertEqual(returned_document.content, post_data['content'])


### PR DESCRIPTION
@dak and @philschatz:

JSON returned from cnx-authoring will now use `revised` instead of `modified`.
