### PR TITLE
allow for a dynamic list of allowable origin hosts

### DIFF
--- a/cnxauthoring/events.py
+++ b/cnxauthoring/events.py
@@ -11,15 +11,19 @@ from pyramid.events import NewRequest
 def add_cors_headers(request, response):
     settings = request.registry.settings
     acac = settings['cors.access_control_allow_credentials']
-    acao = settings['cors.access_control_allow_origin']
+    acao = settings['cors.access_control_allow_origin'].split()
     acah = settings['cors.access_control_allow_headers']
     acam = settings['cors.access_control_allow_methods']
     if acac:
         response.headerlist.append(
                 ('Access-Control-Allow-Credentials', acac))
     if acao:
-        response.headerlist.append(
-                ('Access-Control-Allow-Origin', acao))
+        if request.host in acao:
+            response.headerlist.append(
+                ('Access-Control-Allow-Origin', request.host))
+        else:   
+            response.headerlist.append(
+                ('Access-Control-Allow-Origin', acao[0]))
     if acah:
         response.headerlist.append(
                 ('Access-Control-Allow-Headers', acah))

--- a/development.ini.example
+++ b/development.ini.example
@@ -3,7 +3,7 @@ use = egg:cnx-authoring
 
 archive.url = http://archive.cnx.org/
 cors.access_control_allow_credentials = true
-cors.access_control_allow_origin = http://localhost:8000
+cors.access_control_allow_origin = http://localhost:8000 http://localhost:8080
 cors.access_control_allow_headers = Origin, Content-Type
 cors.access_control_allow_methods = GET, OPTIONS, PUT, POST
 

--- a/testing.ini
+++ b/testing.ini
@@ -3,7 +3,7 @@ use = egg:cnx-authoring
 
 archive.url = http://archive.cnx.org/
 cors.access_control_allow_credentials = true
-cors.access_control_allow_origin = http://localhost:8000
+cors.access_control_allow_origin = http://localhost:8000 http://localhost:9000
 cors.access_control_allow_headers = Origin, Content-Type
 cors.access_control_allow_methods = GET, OPTIONS, PUT, POST
 


### PR DESCRIPTION
this allows for both dev.localhost and demo.localhost to share a backend.
