### PR TITLE
Exclude tests and include sql files in cnx-authoring package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,13 +27,12 @@ setup(
         url='https://github.com/connexions/cnx-authoring',
         license='LGPL, See also LICENSE.txt',
         description='Unpublished repo',
-        packages=find_packages(),
+        packages=find_packages(exclude=['*.tests', '*.tests.*']),
         install_requires=install_requires,
         tests_require=tests_require,
         package_data={
             'cnxauthoring.storage': ['sql/*.sql', 'sql/*/*.sql'],
             },
-        include_package_data=True,
         entry_points={
             'paste.app_factory': [
                 'main = cnxauthoring:main',


### PR DESCRIPTION
Remove include_package_data=True as it looks for MANIFEST.in instead of
using the package_data that we specified in setup.py.

Tested by running:

``` bash
rm -rf cnx_authoring.egg-info dist
python setup.py sdist
```

Close #51
