### PR TITLE
Search storage tests

### DIFF
--- a/cnxauthoring/storage/memory.py
+++ b/cnxauthoring/storage/memory.py
@@ -83,7 +83,7 @@ class MemoryStorage(BaseStorage):
         pass
     
 
-    def search(self, limits, type_=Document, submitter=None):
+    def search(self, limits, type_=Document, submitter_id=None):
         """Retrieve any ``Document`` objects from storage that matches the
         search terms."""
         if type_ != Document:
@@ -101,5 +101,6 @@ class MemoryStorage(BaseStorage):
             title = title.lower()
             for term in search_terms:
                 if term in title:
-                    if submitter is None or item.metadata.get('submitter') == submitter:
+                    if submitter_id is None or item.metadata.get('submitter')['id'] == submitter_id:
                         yield item
+                        break

--- a/cnxauthoring/views.py
+++ b/cnxauthoring/views.py
@@ -395,7 +395,7 @@ def search_content(request):
         return empty_response
     q = utils.structured_query(q)
 
-    result = storage.search(q, submitter=request.unauthenticated_userid)
+    result = storage.search(q, submitter_id=request.unauthenticated_userid)
     items = []
     for content in result:
         document = content.__json__()


### PR DESCRIPTION
- Search now receives and filters by the submitter's id. 
- Search in postgresql does not filter by submitter if submitter is none. 
- Search in memory returns each document once, even if it matches multiple search terms. 
- Tests added for search  
