### PR TITLE
Update Resource following changes in Connexions/cnx-epub#23

### DIFF
--- a/cnxauthoring/models.py
+++ b/cnxauthoring/models.py
@@ -7,7 +7,6 @@
 # ###
 import datetime
 import io
-import hashlib
 import uuid
 
 import tzlocal
@@ -81,14 +80,9 @@ class Resource(cnxepub.Resource):
 
     def __init__(self, mediatype, data, filename=None):
         # ``data`` must be a buffer or file-like object.
-        try:
-            self.data = data.read()
-        except AttributeError:
-            self.data = data[:]
-        _hash = hashlib.new('sha1', self.data).hexdigest()
-        cnxepub.Resource.__init__(self, _hash, io.BytesIO(self.data),
+        cnxepub.Resource.__init__(self, 'resource_id', data,
                 mediatype, filename)
-        self._hash = _hash
+        self.id = self.hash
 
     def __acl__(self):
         return (

--- a/cnxauthoring/tests/test_storage/test_memory.py
+++ b/cnxauthoring/tests/test_storage/test_memory.py
@@ -5,7 +5,7 @@
 # Public License version 3 (AGPLv3).
 # See LICENCE.txt for details.
 # ###
-
+import io
 import unittest
 import uuid
 
@@ -85,13 +85,14 @@ class MemoryStorageTests(unittest.TestCase):
     def test_add_and_get_resource(self):
         with open(test_data('1x1.png'), 'rb') as f:
             data = f.read()
-        r = Resource('image/png', data)
+        r = Resource('image/png', io.BytesIO(data))
         self.storage.add(r)
         self.storage.persist()
 
         result = self.storage.get(type_=Resource, hash=r.hash)
         self.assertEqual(result.hash, r.hash)
-        self.assertEqual(result.data.read(), data)
+        with result.open() as f:
+            self.assertEqual(f.read(), data)
 
     def test_get_document(self):
         d1_id = uuid.uuid4()

--- a/cnxauthoring/utils.py
+++ b/cnxauthoring/utils.py
@@ -175,7 +175,8 @@ def derive_resources(request, document):
                 except urllib2.HTTPError:
                     continue
                 content_type = response.info().getheader('Content-Type')
-                resources[r.uri] = Resource(content_type, response)
+                resources[r.uri] = Resource(content_type,
+                        io.BytesIO(response.read()))
                 yield resources[r.uri]
             r.bind(resources[r.uri], path)
     document.metadata['content'] = document.html

--- a/cnxauthoring/views.py
+++ b/cnxauthoring/views.py
@@ -6,6 +6,7 @@
 # See LICENCE.txt for details.
 # ###
 import functools
+import io
 import json
 try:
     from urllib import urlencode # python 2
@@ -187,8 +188,8 @@ def get_resource(request):
     if not request.has_permission('view', resource):
         raise httpexceptions.HTTPForbidden()
     resp = request.response
-    resp.body = resource.data.read()
-    resource.data.seek(0)
+    with resource.open() as data:
+        resp.body = data.read()
     resp.content_type = resource.media_type
     if 'html' in resp.content_type:
         resp.content_type = 'application/octet-stream'
@@ -314,7 +315,7 @@ def post_resource(request):
     mediatype = file_form_field.type
     data = file_form_field.file
 
-    resource = Resource(mediatype, data)
+    resource = Resource(mediatype, io.BytesIO(data.read()))
     if not request.has_permission('create', resource):
         raise httpexceptions.HTTPForbidden()
 


### PR DESCRIPTION
- Use `with resource.open() as f: f.read()` instead of `resource.data`
- Directly create `io.BytesIO` objects for Resource data
- Remove code to generate sha1 hash and use the cnxepub.Resource hash
