### PR TITLE
Limit file uploads to 50M (configured in development.ini)

### DIFF
--- a/cnxauthoring/tests/test_functional.py
+++ b/cnxauthoring/tests/test_functional.py
@@ -1804,6 +1804,14 @@ class FunctionalTests(BaseFunctionalTestCase):
                 b'f572d396fae9206628714fb2ce00f72e94f2258f')
         self.assert_cors_headers(response)
 
+    def test_post_resource_exceed_size_limit(self):
+        two_mb = b'x' * 2 * 1024 * 1024
+        response = self.testapp.post('/resources',
+                # a 2MB file, size limit for tests is 1MB
+                {'file': Upload('a.txt', two_mb, 'text/plain')},
+                status=400)
+        self.assertIn(b'File uploaded has exceeded limit 1MB', response.body)
+
     def test_user_search_no_q(self):
         response = self.testapp.get('/users/search')
         result = json.loads(response.body.decode('utf-8'))

--- a/cnxauthoring/tests/test_views.py
+++ b/cnxauthoring/tests/test_views.py
@@ -207,6 +207,7 @@ class ViewsTests(unittest.TestCase):
         # Minimal document posts require a title.
         request = testing.DummyRequest()
         request.POST = {'file': upload}
+        request.registry.settings['authoring.file_upload.limit'] = '50'
         from ..views import post_resource
         location = post_resource(request)
 

--- a/cnxauthoring/views.py
+++ b/cnxauthoring/views.py
@@ -347,6 +347,12 @@ def post_resource(request):
     resource = Resource(mediatype, io.BytesIO(data.read()))
     if not request.has_permission('create', resource):
         raise httpexceptions.HTTPForbidden()
+    size_limit = request.registry.settings['authoring.file_upload.limit']
+    with resource.open() as f:
+        data = f.read()
+    if len(data) > int(size_limit) * 1024 * 1024:
+        raise httpexceptions.HTTPBadRequest(
+                'File uploaded has exceeded limit {}MB'.format(size_limit))
 
     try:
         resource = storage.add(resource)

--- a/development.ini.example
+++ b/development.ini.example
@@ -13,6 +13,9 @@ storage = memory
 pickle.filename = dev.p
 postgresql.db-connection-string = dbname=authoring user=cnxauthoring
 
+# size limit of file upload in MB
+authoring.file_upload.limit = 50
+
 openstax_accounts.server_url = https://localhost:3000/
 openstax_accounts.application_id = a86119f2635afb0c2f1b89fc914e65e09688451168b639a18fd054f2e4b15670
 openstax_accounts.application_secret = 9bbe5046b799ce150218417493cfb014894b43c07a184ad990dd607ed92b63bb

--- a/testing.ini
+++ b/testing.ini
@@ -14,6 +14,9 @@ postgresql.db-connection-string = dbname=authoring-test user=cnxauthoring passwo
 
 pickle.filename = test.p
 
+# size limit of file upload in MB
+authoring.file_upload.limit = 1
+
 openstax_accounts.stub = true
 openstax_accounts.stub.users =
     me,password,{"username": "me", "id": 1, "first_name": "User", "last_name": "One", "contact_infos": [{"type": "EmailAddress", "verified": true, "id": 1, "value": "me@example.com"}]}


### PR DESCRIPTION
MANUAL-UPGRADE: Add authoring.file_upload.limit setting in
development.ini (See development.ini.example or testing.ini)
