### PR TITLE
Fix datetime localization in tests and pin pytz.

### DIFF
--- a/cnxauthoring/models.py
+++ b/cnxauthoring/models.py
@@ -265,8 +265,10 @@ def build_metadata(title, id=None, content=None, abstract=None, created=None,
 def to_dict(metadata):
     result = metadata.copy()
     result['id'] = str(result['id'])
-    result['created'] = result['created'].isoformat()
-    result['revised'] = result['revised'].isoformat()
+    created = result['created']
+    revised = result['revised']
+    result['created'] = created.astimezone(TZINFO).isoformat()
+    result['revised'] = revised.astimezone(TZINFO).isoformat()
     result['license'] = result['license'].__dict__.copy()
     return result
 

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ install_requires = (
         'pyramid',
         'psycopg2>=2.5',
         'requests',
+        'pytz',
         'tzlocal',
         'waitress',
         )


### PR DESCRIPTION
Using this has been the only way I can get the tests to pass. They are passing for @reedstrm and @karenc, so I'm not sure what the problem is.

These changes make the data more accurate. That is to say, the test case posts data from a different timezone. The given iso8601 timestamp is entered into Postgresql, which will accept a timestamp from any timezone.

I don't know what the issue is. So this is a pull request that needs another pair of eyes.
