### PR TITLE
Add a functional test for republishing content after "Failed/Error"

### DIFF
--- a/cnxauthoring/views.py
+++ b/cnxauthoring/views.py
@@ -453,6 +453,7 @@ def put_content(request):
     except Exception as e:
         raise httpexceptions.HTTPBadRequest(body=json.dumps(e.asdict()))
 
+    appstruct['state'] = 'Draft'
     try:
         content.update(**appstruct)
     except DocumentNotFoundError as e:


### PR DESCRIPTION
Reset content to "Draft" if PUT /contents/<id>@draft.json
