### PR TITLE
Only allow users to delete themselves from the content

### DIFF
--- a/cnxauthoring/tests/test_functional.py
+++ b/cnxauthoring/tests/test_functional.py
@@ -1727,6 +1727,12 @@ class FunctionalTests(BaseFunctionalTestCase):
         self.testapp.get(
                 '/contents/{}@draft.json'.format(page['id']), status=200)
 
+        # delete user2 from the content should fail, because user can only
+        # remove themselves from the content
+        self.testapp.delete(
+            '/contents/{}@draft/users/user2.json'.format(page['id']),
+            status=403)
+
         # delete user1 from the content
         self.testapp.delete(
                 '/contents/{}@draft/users/user1.json'.format(page['id']),

--- a/cnxauthoring/views.py
+++ b/cnxauthoring/views.py
@@ -400,6 +400,9 @@ def delete_content(request):
     if not request.has_permission('edit', content):
         raise httpexceptions.HTTPForbidden(
                 'You do not have permission to delete {}'.format(id))
+    if user_id and user_id != request.authenticated_userid:
+        raise httpexceptions.HTTPForbidden(
+            'You can only remove yourself from this document {}'.format(id))
     if not user_id and len(content.acls) > 1:
         # there are other users who have permission to this document
         raise httpexceptions.HTTPForbidden(


### PR DESCRIPTION
Change DELETE /contents/<content-id>/users/<userid>.json to return 403
Forbidden if userid is not the logged in user.
