### PR TITLE
Add extra content status "Awaiting acceptance" in workspace API

### DIFF
--- a/cnxauthoring/tests/test_functional.py
+++ b/cnxauthoring/tests/test_functional.py
@@ -2406,10 +2406,11 @@ class FunctionalTests(BaseFunctionalTestCase):
         self.login('user2')
         response = self.testapp.get('/users/contents', status=200)
         result = json.loads(response.body.decode('utf-8'))
-        content_ids = [(i['id'], i['rolesToAccept'])
-            for i in result['results']['items']]
-        self.assertIn(('{}@draft'.format(page['id']), ['editors']),
-                      content_ids)
+        content_ids = [(i['id'], i['rolesToAccept'], i['state'])
+                       for i in result['results']['items']]
+        self.assertIn(
+            ('{}@draft'.format(page['id']), ['editors'], 'Awaiting acceptance'
+             ), content_ids)
         self.assert_cors_headers(response)
 
         self.testapp.get(

--- a/cnxauthoring/views.py
+++ b/cnxauthoring/views.py
@@ -172,6 +172,8 @@ def user_contents(request):
             for role in item.get(role_key, []):
                 if role['id'] == user_id and role.get('hasAccepted') is None:
                     document['rolesToAccept'].append(role_key)
+        if document['rolesToAccept']:
+            document['state'] = 'Awaiting acceptance'
 
         items.append(document)
 


### PR DESCRIPTION
If there are roles to accept on a piece of content, instead of returning
"Draft" as the status, return "Awaiting acceptance".

Close Connexions/webview#800
