### PR TITLE
Fix permission issues regarding roles

### DIFF
--- a/cnxauthoring/models.py
+++ b/cnxauthoring/models.py
@@ -150,7 +150,8 @@ class BaseContent:
         result = self.to_dict()
         utils.change_dict_keys(result, utils.underscore_to_camelcase)
         if request and hasattr(self,'acls'):
-           result['permissions'] = sorted(self.acls[request.unauthenticated_userid])
+           result['permissions'] = sorted(self.acls.get(
+               request.unauthenticated_userid, []))
         return result
 
 

--- a/cnxauthoring/tests/test_utils.py
+++ b/cnxauthoring/tests/test_utils.py
@@ -173,7 +173,8 @@ class UtilsTests(unittest.TestCase):
             authors=[{'id': 'author'}, {'id': 'me'}],
             editors=[{'id': 'editor'}],
             translators=[{'id': 'translator'}, {'id': 'you'}],
-            publishers=[{'id': 'me'}, {'id': 'you'}],
+            publishers=[{'id': 'me', 'has_accepted': True},
+                        {'id': 'you', 'has_accepted': True}],
             licensors=[{'id': 'licensor'}],
             illustrators=[{'id': 'illustrator'}],
             )

--- a/cnxauthoring/views.py
+++ b/cnxauthoring/views.py
@@ -169,7 +169,7 @@ def user_contents(request):
         # check if there are roles to accept
         document['rolesToAccept'] = []
         for role_key in ATTRIBUTED_ROLE_KEYS:
-            for role in item.get(role_key, []):
+            for role in content.metadata.get(role_key, []):
                 if role['id'] == user_id and role.get('hasAccepted') is None:
                     document['rolesToAccept'].append(role_key)
         if document['rolesToAccept']:
@@ -557,7 +557,8 @@ def put_content(request):
     resp.headers.add(
             'Location',
             request.route_url('get-content-json', id=content.id))
-    content.metadata['permissions'] = sorted(content.acls[request.unauthenticated_userid])
+    content.metadata['permissions'] = sorted(content.acls.get(
+        request.unauthenticated_userid, []))
     return content
 
 


### PR DESCRIPTION
Fix permission issues regarding roles
- Only give publish permission once a user has accepted the publisher
  role
- Always give a user view permission if the user has roles awaiting
  acceptance
- Add test case for partial role acceptance
