### PR TITLE
Show "Rejected roles" in workspace if user has rejected all roles

### DIFF
--- a/cnxauthoring/utils.py
+++ b/cnxauthoring/utils.py
@@ -291,10 +291,9 @@ def get_acl_for(request, document):
                 permissions.append('publish')
             if role.get('has_accepted'):
                 permissions.append('edit')
-                permissions.append('view')
             if role.get('has_accepted') is None:
-                permissions.append('view')
                 users_pending_acceptance.append(role['id'])
+            permissions.append('view')
             roles_acl.setdefault(role['id'], set([]))
             roles_acl[role['id']].update(permissions)
 


### PR DESCRIPTION
If a user rejects all roles, they can still see it in their workspace
with status "Rejected roles" in case they change their minds.
They can remove it from their workspace using the delete API.
