### PR TITLE
Remove rejected roles on save

### DIFF
--- a/cnxauthoring/utils.py
+++ b/cnxauthoring/utils.py
@@ -314,9 +314,13 @@ def accept_roles(cstruct, user):
     for field in cnxepub.ATTRIBUTED_ROLE_KEYS + ('licensors',):
         if field in cstruct:
             value = cstruct.get(field, [])
-            for role in value:
+            for i, role in enumerate(value):
                 if role.get('id') == user['id']:
-                    role['has_accepted'] = True
+                    if role.get('has_accepted', None) not in (None, True,):
+                        # Remove the role.
+                        del value[i]
+                    else:
+                        role['has_accepted'] = True
                     if not role.get('requester'):
                         role['requester'] = authenticated_userid
                         role['assignment_date'] = now


### PR DESCRIPTION
This will only remove the rejected roles for the authenticated user. It will not remove the rejected roles of others.
