### PR TITLE
adding in a printStyle metadata parameter

### DIFF
--- a/cnxauthoring/models.py
+++ b/cnxauthoring/models.py
@@ -266,7 +266,7 @@ def build_metadata(
         submitter=None, state=None, publication=None, cnx_archive_uri=None,
         authors=None, publishers=None, contained_in=None,
         licensors=None, copyright_holders=None,
-        editors=None, translators=None, illustrators=None):
+        editors=None, translators=None, illustrators=None, print_style=None):
     metadata = {}
     metadata['title'] = title
     metadata['version'] = version is None and 'draft' or version
@@ -312,6 +312,7 @@ def build_metadata(
     metadata['editors'] = editors or []
     metadata['translators'] = translators or []
     metadata['illustrators'] = illustrators or []
+    metadata['print_style'] = print_style
     return metadata
 
 

--- a/cnxauthoring/schemata.py
+++ b/cnxauthoring/schemata.py
@@ -228,6 +228,10 @@ class DocumentSchema(colander.MappingSchema):
         colander.List(),
         missing=colander.drop,
         )
+    print_style = colander.SchemaNode(
+        colander.String(),
+        missing=colander.drop,
+        )
 
 document_schema = DocumentSchema()
 

--- a/cnxauthoring/storage/sql/add-document.sql
+++ b/cnxauthoring/storage/sql/add-document.sql
@@ -13,11 +13,11 @@ INSERT INTO document (license, language, created, abstract, media_type,
                       cnx_archive_uri, subjects, keywords, state,
                       publication, publishers, contained_in,
                       copyright_holders, editors, translators,
-                      illustrators, version)
+                      illustrators, version, print_style)
     VALUES(%(license)s, %(language)s, %(created)s, %(abstract)s, %(media_type)s,
            %(title)s, %(revised)s, %(content)s, %(derived_from)s, %(submitter)s,
            %(authors)s, %(id)s, %(derived_from_title)s, %(derived_from_uri)s,
            %(cnx-archive-uri)s, %(subjects)s, %(keywords)s, %(state)s,
            %(publication)s, %(publishers)s, %(contained_in)s,
            %(copyright_holders)s, %(editors)s, %(translators)s,
-           %(illustrators)s, %(version)s);
+           %(illustrators)s, %(version)s,  %(print_style)s);

--- a/cnxauthoring/storage/sql/schema/document.sql
+++ b/cnxauthoring/storage/sql/schema/document.sql
@@ -23,5 +23,6 @@ CREATE TABLE document ( id                 uuid primary key,
                         publication        text,
                         cnx_archive_uri    text,
                         version            text,
-                        contained_in       text[]
+                        contained_in       text[],
+                        print_style    text
                     );

--- a/cnxauthoring/storage/sql/update-document.sql
+++ b/cnxauthoring/storage/sql/update-document.sql
@@ -22,5 +22,5 @@ UPDATE document
             contained_in = %(contained_in)s,
             copyright_holders = %(copyright_holders)s,
             editors = %(editors)s, translators = %(translators)s,
-            illustrators = %(illustrators)s, version = %(version)s
+            illustrators = %(illustrators)s, version = %(version)s, print_style = %(print_style)s
 WHERE id  = %(id)s

--- a/cnxauthoring/tests/test_functional.py
+++ b/cnxauthoring/tests/test_functional.py
@@ -278,6 +278,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'translators': [],
             u'editors': [],
             u'illustrators': [],
+            u'printStyle': None,
             })
         self.assertEqual(put_result, get_result)
         self.assert_cors_headers(response)
@@ -353,6 +354,23 @@ class FunctionalTests(BaseFunctionalTestCase):
             result['id']), status=200)
         self.assert_cors_headers(response)
 
+    def test_post_content_document_printStyle(self):
+        response = self.testapp.post_json(
+            '/users/contents',
+            {
+                'title': u'My document タイトル',
+                'printStyle': u'pdf print style string'
+            }, status=201)
+        result = response.json
+        self.assertEqual(result['title'], u'My document タイトル')
+        self.assertEqual(result['language'], u'en')
+        self.assertEqual(result['printStyle'], 'pdf print style string')
+        self.assert_cors_headers(response)
+
+        response = self.testapp.get('/contents/{}@draft.json'.format(
+            result['id']), status=200)
+        self.assert_cors_headers(response)
+
     def test_post_content_minimal_binder(self):
         response = self.testapp.post_json('/users/contents', {
                     'title': u'My book タイトル',
@@ -386,6 +404,45 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'publishBlockers': [u'no_content'],
             u'title': result['title'],
             })
+        self.assert_cors_headers(response)
+
+    def test_post_content_minimal_binder_with_printStyle(self):
+        response = self.testapp.post_json('/users/contents', {
+            'title': u'My book タイトル',
+            'mediaType': 'application/vnd.org.cnx.collection',
+            'tree': {
+                'contents': [],
+            },
+            'printStyle': "*PDF print style*"
+        }, status=201)
+        result = response.json
+
+        self.assertEqual(result['title'], u'My book タイトル')
+        self.assertEqual(result['language'], u'en')
+        self.assertEqual(result['tree'], {
+            u'contents': [],
+            u'id': '{}@draft'.format(result['id']),
+            u'title': result['title'],
+            u'isPublishable': False,
+            u'publishBlockers': [u'no_content'],
+        })
+        self.assertEqual(result['printStyle'], '*PDF print style*')
+
+        self.assert_cors_headers(response)
+
+        response = self.testapp.get(
+            '/contents/{}@draft.json'.format(result['id']), status=200)
+        result = response.json
+        self.assertEqual(result['title'], u'My book タイトル')
+        self.assertEqual(result['language'], u'en')
+        self.assertEqual(result['tree'], {
+            u'contents': [],
+            u'id': '{}@draft'.format(result['id']),
+            u'isPublishable': False,
+            u'publishBlockers': [u'no_content'],
+            u'title': result['title'],
+        })
+        self.assertEqual(result['printStyle'], '*PDF print style*')
         self.assert_cors_headers(response)
 
     def test_post_content_binder_document_not_found(self):
@@ -486,6 +543,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'licensors': [submitter_w_assign_date],
             u'copyrightHolders': [submitter_w_assign_date],
             u'illustrators': [],
+            u'printStyle': None,
             })
         self.assert_cors_headers(response)
 
@@ -530,6 +588,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'licensors': [submitter_w_assign_date],
             u'copyrightHolders': [submitter_w_assign_date],
             u'illustrators': [],
+            u'printStyle': None,
             })
         self.assert_cors_headers(response)
 
@@ -593,6 +652,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'licensors': [submitter_w_assign_date],
             u'copyrightHolders': [submitter_w_assign_date],
             u'illustrators': [],
+            u'printStyle': None,
             })
         self.assert_cors_headers(response)
 
@@ -637,6 +697,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'licensors': [submitter_w_assign_date],
             u'copyrightHolders': [submitter_w_assign_date],
             u'illustrators': [],
+            u'printStyle': None,
             })
         self.assert_cors_headers(response)
 
@@ -698,6 +759,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'licensors': [submitter_w_assign_date],
             u'copyrightHolders': [submitter_w_assign_date],
             u'illustrators': [],
+            u'printStyle': None,
             })
         self.assert_cors_headers(response)
 
@@ -742,6 +804,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'licensors': [submitter_w_assign_date],
             u'copyrightHolders': [submitter_w_assign_date],
             u'illustrators': [],
+            u'printStyle': None,
             })
         self.assert_cors_headers(response)
 
@@ -793,6 +856,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'editors': [],
             u'translators': [],
             u'licensors': [submitter_w_assign_date],
+            u'printStyle': None,
             u'copyrightHolders': [submitter_w_assign_date],
             u'illustrators': [],
             u'subjects': [],
@@ -951,7 +1015,9 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'submitter': rasmus_user_info,
             u'title': u'Turning DNA through resonance',
             u'translators': [],
-            u'version': u'draft'})
+            u'version': u'draft',
+            u'printStyle': None,
+        })
         self.assert_cors_headers(response)
 
         response = self.testapp.get(
@@ -996,6 +1062,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'licensors': [rasmus_role],
             u'copyrightHolders': [rasmus_role],
             u'illustrators': [],
+            u'printStyle': None,
             })
         self.assert_cors_headers(response)
 
@@ -1116,6 +1183,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'title': u'College Physics',
             u'translators': [],
             u'version': u'draft',
+            u'printStyle': None,
             }
         self.assertEqual(result, expected)
         self.assert_cors_headers(response)
@@ -1201,6 +1269,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'licensors': [submitter_w_assign_date],
             u'copyrightHolders': [submitter_w_assign_date],
             u'illustrators': [],
+            u'printStyle': None,
             })
         self.assert_cors_headers(response)
 
@@ -1317,6 +1386,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'licensors': [submitter_w_assign_date],
             u'copyrightHolders': [submitter_w_assign_date],
             u'illustrators': [],
+            u'printStyle': None,
             })
         self.assert_cors_headers(response)
 
@@ -1508,6 +1578,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'licensors': [submitter_w_assign_date],
             u'copyrightHolders': [submitter_w_assign_date],
             u'illustrators': [],
+            u'printStyle': None,
             })
         self.assert_cors_headers(response)
 
@@ -1561,6 +1632,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'licensors': [submitter_w_assign_date],
             u'copyrightHolders': [submitter_w_assign_date],
             u'illustrators': [],
+            u'printStyle': None,
             })
         self.assert_cors_headers(response)
 
@@ -3098,6 +3170,83 @@ class PublicationTests(BaseFunctionalTestCase):
                             ],
                         },
                     }, status=201)
+        self.assert_cors_headers(response)
+        binder = response.json
+
+        post_data = {
+            'submitlog': 'Publishing a book is working?',
+            'items': (binder['id'], page1['id'], page2['id'],),
+            }
+        response = self.testapp.post_json('/publish', post_data, status=200)
+        self.assertEqual(response.json[u'state'], u'Done/Success')
+        expected_mapping = {
+            binder['id']: '{}@1.1'.format(binder['id']),
+            page1['id']: '{}@1'.format(page1['id']),
+            page2['id']: '{}@1'.format(page2['id']),
+            }
+        self.assertEqual(response.json[u'mapping'], expected_mapping)
+        self.assert_cors_headers(response)
+
+        # Grab the publication id for followup assertions.
+        publication_id = response.json['publication']
+
+        for page in (binder, page1, page2,):
+            url = '/contents/{}@draft.json'.format(page['id'])
+            response = self.testapp.get(url)
+            self.assertEqual(response.json['state'], 'Done/Success')
+            self.assertEqual(response.json['publication'],
+                             str(publication_id))
+
+    def test_publish_binder_w_printStyle(self):
+        #################################################################
+        # FIXME: this test will probably need to be modified once the   #
+        # print style has be added to publishing                        #
+        #################################################################
+        response = self.testapp.post_json('/users/contents', {
+            'title': 'Page one',
+            'content': '<html><body><p>Content of page one</p></body></html>',
+            'abstract': 'Learn how to etc etc',
+            'printStyle': '*PDF Print Style*',
+            }, status=201)
+        page1 = response.json
+        self.assert_cors_headers(response)
+
+        response = self.testapp.post_json('/users/contents', {
+            'title': 'Page two',
+            'content': '<html><body><p>Content of page two</p></body></html>',
+            'printStyle': '[PDF Print Style]'
+            }, status=201)
+        page2 = response.json
+        self.assert_cors_headers(response)
+        page1_str = '{}@draft'.format(page1['id'])
+        page2_str = '{}@draft'.format(page2['id'])
+        response = self.testapp.post_json(
+            '/users/contents',
+            {
+                'title': 'Book',
+                'abstract': 'Book abstract',
+                'language': 'de',
+                'mediaType': 'application/vnd.org.cnx.collection',
+                'tree': {
+                            'contents': [
+                                {
+                                    'id': page1_str,
+                                    'title': 'Page one',
+                                },
+                                {
+                                    'id': 'subcol',
+                                    'title': 'New section',
+                                    'contents': [
+                                        {
+                                            'id': page2_str,
+                                            'title': 'Page two',
+                                        },
+                                    ],
+                                },
+                            ],
+                },
+            }, status=201)
+
         self.assert_cors_headers(response)
         binder = response.json
 

--- a/cnxauthoring/tests/test_modifiers.py
+++ b/cnxauthoring/tests/test_modifiers.py
@@ -45,6 +45,7 @@ class ModelJSONRendering(unittest.TestCase):
             'created': document.metadata['created'].isoformat(),
             'revised': document.metadata['revised'].isoformat(),
             'mediaType': Document.mediatype,
+            'printStyle': None,
             'language': 'en',
             'version': 'draft',
             'submitter': None,

--- a/cnxauthoring/views.py
+++ b/cnxauthoring/views.py
@@ -381,7 +381,6 @@ def post_content(request):
         cstruct = request.json_body
     except (TypeError, ValueError):
         raise httpexceptions.HTTPBadRequest('Invalid JSON')
-
     contents = []
     content = None
     try:


### PR DESCRIPTION
Authoring now saves the printStyle parameter in its database and passes this parameter to cnx-publishing. 
 
Close #197 