### PR TITLE
Fix Access-Control-Allow-Origin to return the request origin

### DIFF
--- a/cnxauthoring/events.py
+++ b/cnxauthoring/events.py
@@ -18,9 +18,9 @@ def add_cors_headers(request, response):
         response.headerlist.append(
                 ('Access-Control-Allow-Credentials', acac))
     if acao:
-        if request.host in acao:
+        if request.headers.get('Origin') in acao:
             response.headerlist.append(
-                ('Access-Control-Allow-Origin', request.host))
+                ('Access-Control-Allow-Origin', request.headers.get('Origin')))
         else:   
             response.headerlist.append(
                 ('Access-Control-Allow-Origin', acao[0]))


### PR DESCRIPTION
request.host is the host part of the request url.  For example, if
webview is trying to access http://localhost:8080/users/profile,
request.  It's the Origin field in the headers that we should be
matching.