### PR TITLE
Update setuptools to >=17.1 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ install_requires = (
         'psycopg2>=2.5',
         'requests',
         'pytz',
+        'setuptools>=17.1',
         'tzlocal',
         'waitress',
         )


### PR DESCRIPTION
I tried 2 fixes (see the 2 commits), both worked:

 - Use mock version to 1.0.1 in setup.py
  
  mock >= 1.1.0 requires setuptools >= 17.1 which is too new

  (The requirement was added in 1.1.3, but 1.1.0 is the first version that
  stopped working)

 - Try upgrading setuptools to >= 17.1

Which one is better?