### PR TITLE
Revert "Update setuptools to >=17.1 in setup.py"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ install_requires = (
         'psycopg2>=2.5',
         'requests',
         'pytz',
-        'setuptools>=17.1',
         'tzlocal',
         'waitress',
         )

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,9 @@ tests_require = (
         'cnx-archive',
         'cnx-publishing',
         'HTTPretty',
-        'mock',   # only required for python2
+        # FIXME mock>1.1 uses setuptools>17.1 which is not available
+        #       in debian/ubuntu stable.
+        'mock==1.0.1',   # only required for python2
         'WebTest',
         'wsgi_intercept',
         )


### PR DESCRIPTION
Reverts Connexions/cnx-authoring#229

This is being reverted because it may not work as expect on Debian system that use an outdated setuptools.

A followup commit will be made that pins setuptools to ``<17``.