### PR TITLE
Upgrade license on revision, as well

### DIFF
--- a/cnxauthoring/models.py
+++ b/cnxauthoring/models.py
@@ -486,8 +486,9 @@ def revise_content(request, **kwargs):
     document['maintainers'] = document['publishers']
     # Upgrade the license
     if document['license']['url'] not in [l.url for l in CURRENT_LICENSES]:
-        license = License.from_url(document['license']['url'])
-        document['license'] = _upgrade_license(license).__json__()
+        license = _upgrade_license(License.from_url(document['license']['url'])).__json__()
+        license['upgraded']=True
+        document['license'] = license
     return document
 
 

--- a/cnxauthoring/models.py
+++ b/cnxauthoring/models.py
@@ -484,6 +484,10 @@ def revise_content(request, **kwargs):
     document.update(kwargs)
     document['revised'] = None
     document['maintainers'] = document['publishers']
+    # Upgrade the license
+    if document['license']['url'] not in [l.url for l in CURRENT_LICENSES]:
+        license = License.from_url(document['license']['url'])
+        document['license'] = _upgrade_license(license).__json__()
     return document
 
 

--- a/cnxauthoring/models.py
+++ b/cnxauthoring/models.py
@@ -486,8 +486,10 @@ def revise_content(request, **kwargs):
     document['maintainers'] = document['publishers']
     # Upgrade the license
     if document['license']['url'] not in [l.url for l in CURRENT_LICENSES]:
-        license = _upgrade_license(License.from_url(document['license']['url'])).__json__()
-        license['upgraded']=True
+        license = _upgrade_license(
+            License.from_url(
+                document['license']['url'])).__json__()
+        license['upgraded'] = True
         document['license'] = license
     return document
 

--- a/cnxauthoring/tests/test_models.py
+++ b/cnxauthoring/tests/test_models.py
@@ -43,7 +43,7 @@ class ModelUtilitiesTestCase(unittest.TestCase):
             'illustrators': [{}, {}, {}],
             'created': 'awhile ago',
             'revised': 'just now',
-            }
+        }
 
         url = "{}/contents/{}.json".format(archive_url, content_id)
         faux_response_body = json.dumps(archived_data)
@@ -60,8 +60,9 @@ class ModelUtilitiesTestCase(unittest.TestCase):
         expected = archived_data.copy()
         role_attrs = ('authors', 'licensors', 'editors', 'illustrators',
                       'maintainers', 'publishers', 'translators',)
-        for role_attr in  role_attrs:
-            expected[role_attr] = [{'has_accepted':True},{'has_accepted':True},{'has_accepted':True}]
+        for role_attr in role_attrs:
+            expected[role_attr] = [
+                {'has_accepted': True}, {'has_accepted': True}, {'has_accepted': True}]
         expected['revised'] = None
         self.assertEqual(document_as_dict, expected)
 
@@ -81,7 +82,7 @@ class ModelUtilitiesTestCase(unittest.TestCase):
             'license': license.__json__(),
             'title': content_title,
             'publishers': [{}, {}, {}],
-            }
+        }
 
         url = "{}/contents/{}.json".format(archive_url, content_id)
         faux_response_body = json.dumps(archived_data)
@@ -97,8 +98,7 @@ class ModelUtilitiesTestCase(unittest.TestCase):
 
         self.assertEqual(document_as_dict['license']['version'],
                          DEFAULT_LICENSE.version)
-        self.assertEqual(document_as_dict['license']['upgraded'],True)
-
+        self.assertEqual(document_as_dict['license']['upgraded'], True)
 
     @httpretty.activate
     def test_revise_content_upgrades_to_comparable_license(self):
@@ -117,7 +117,7 @@ class ModelUtilitiesTestCase(unittest.TestCase):
             'license': license.__json__(),
             'title': content_title,
             'publishers': [{}, {}, {}],
-            }
+        }
 
         url = "{}/contents/{}.json".format(archive_url, content_id)
         faux_response_body = json.dumps(archived_data)
@@ -137,7 +137,7 @@ class ModelUtilitiesTestCase(unittest.TestCase):
                          expected_license.code)
         self.assertEqual(document_as_dict['license']['version'],
                          expected_license.version)
-        self.assertEqual(document_as_dict['license']['upgraded'],True)
+        self.assertEqual(document_as_dict['license']['upgraded'], True)
 
     @httpretty.activate
     def test_derive_content(self):

--- a/cnxauthoring/tests/test_models.py
+++ b/cnxauthoring/tests/test_models.py
@@ -22,6 +22,122 @@ class ModelUtilitiesTestCase(unittest.TestCase):
     maxDiff = None
 
     @httpretty.activate
+    def test_revise_content(self):
+        archive_url = "http://example.com"
+        settings = {'archive.url': archive_url}
+
+        from ..models import DEFAULT_LICENSE
+        content_id = 'uuid'
+        content_title = 'title'
+        archived_data = {
+            'id': content_id,
+            'version': '1',
+            'license': DEFAULT_LICENSE.__json__(),
+            'title': content_title,
+            'authors': [{}, {}, {}],
+            'maintainers': [{}, {}, {}],
+            'publishers': [{}, {}, {}],
+            'licensors': [{}, {}, {}],
+            'translators': [{}, {}, {}],
+            'editors': [{}, {}, {}],
+            'illustrators': [{}, {}, {}],
+            'created': 'awhile ago',
+            'revised': 'just now',
+            }
+
+        url = "{}/contents/{}.json".format(archive_url, content_id)
+        faux_response_body = json.dumps(archived_data)
+        httpretty.register_uri(httpretty.GET, url,
+                               body=faux_response_body, status=200)
+
+        request = pyramid_testing.DummyRequest()
+        request.registry = mock.Mock()
+        request.registry.settings = settings
+
+        from ..models import revise_content
+        document_as_dict = revise_content(request, id=content_id)
+
+        expected = archived_data.copy()
+        role_attrs = ('authors', 'licensors', 'editors', 'illustrators',
+                      'maintainers', 'publishers', 'translators',)
+        for role_attr in  role_attrs:
+            expected[role_attr] = [{'has_accepted':True},{'has_accepted':True},{'has_accepted':True}]
+        expected['revised'] = None
+        self.assertEqual(document_as_dict, expected)
+
+    @httpretty.activate
+    def test_revise_content_upgrades_license(self):
+        archive_url = "http://example.com"
+        settings = {'archive.url': archive_url}
+
+        from ..models import LICENSES, DEFAULT_LICENSE
+        license = [l for l in LICENSES if l.url.find('by/3') >= 0][0]
+
+        content_id = 'uuid'
+        content_title = 'title'
+        archived_data = {
+            'id': content_id,
+            'version': '1',
+            'license': license.__json__(),
+            'title': content_title,
+            'publishers': [{}, {}, {}],
+            }
+
+        url = "{}/contents/{}.json".format(archive_url, content_id)
+        faux_response_body = json.dumps(archived_data)
+        httpretty.register_uri(httpretty.GET, url,
+                               body=faux_response_body, status=200)
+
+        request = pyramid_testing.DummyRequest()
+        request.registry = mock.Mock()
+        request.registry.settings = settings
+
+        from ..models import revise_content
+        document_as_dict = revise_content(request, id=content_id)
+
+        self.assertEqual(document_as_dict['license']['version'],
+                         DEFAULT_LICENSE.version)
+
+
+    @httpretty.activate
+    def test_revise_content_upgrades_to_comparable_license(self):
+        archive_url = "http://example.com"
+        settings = {'archive.url': archive_url}
+
+        set_up_licenses()
+        from ..models import LICENSES, CURRENT_LICENSES, DEFAULT_LICENSE
+        license = [l for l in LICENSES if l.url.find('nc-sa/3') >= 0][0]
+
+        content_id = 'uuid'
+        content_title = 'title'
+        archived_data = {
+            'id': content_id,
+            'version': '1',
+            'license': license.__json__(),
+            'title': content_title,
+            'publishers': [{}, {}, {}],
+            }
+
+        url = "{}/contents/{}.json".format(archive_url, content_id)
+        faux_response_body = json.dumps(archived_data)
+        httpretty.register_uri(httpretty.GET, url,
+                               body=faux_response_body, status=200)
+
+        request = pyramid_testing.DummyRequest()
+        request.registry = mock.Mock()
+        request.registry.settings = settings
+
+        from ..models import revise_content
+        document_as_dict = revise_content(request, id=content_id)
+
+        expected_license = [l for l in CURRENT_LICENSES
+                            if l.url.find('nc-sa/4') >= 0][0]
+        self.assertEqual(document_as_dict['license']['code'],
+                         expected_license.code)
+        self.assertEqual(document_as_dict['license']['version'],
+                         expected_license.version)
+
+    @httpretty.activate
     def test_derive_content(self):
         archive_url = "http://example.com"
         settings = {'archive.url': archive_url}

--- a/cnxauthoring/tests/test_models.py
+++ b/cnxauthoring/tests/test_models.py
@@ -97,6 +97,7 @@ class ModelUtilitiesTestCase(unittest.TestCase):
 
         self.assertEqual(document_as_dict['license']['version'],
                          DEFAULT_LICENSE.version)
+        self.assertEqual(document_as_dict['license']['upgraded'],True)
 
 
     @httpretty.activate
@@ -136,6 +137,7 @@ class ModelUtilitiesTestCase(unittest.TestCase):
                          expected_license.code)
         self.assertEqual(document_as_dict['license']['version'],
                          expected_license.version)
+        self.assertEqual(document_as_dict['license']['upgraded'],True)
 
     @httpretty.activate
     def test_derive_content(self):


### PR DESCRIPTION
Currently, we will checkout code to authoring with a license that is not valid for publication. This leads to errors on attempting to publish. This upgrades the license, and tags it as upgraded so that webview can DTRT in the UI (emphasize the upgrade in the accept license dialog, probably) 