### PR TITLE
Workspace search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,12 @@ before_install:
   # Install the coverage utility and coveralls reporting utility
   - pip install coverage
   - pip install coveralls
+
+  # Uninstall mock to fix error
+  # VersionConflict: (mock 1.3.0 ... Requirement.parse('mock==1.0.1'))
+  # (See Pull Request #241, Travis Build #1088)
+  - pip uninstall -y mock
+
 install:
   - python setup.py install
   - cnx-authoring-initialize_db cnxauthoring/tests/testing.ini

--- a/cnxauthoring/__init__.py
+++ b/cnxauthoring/__init__.py
@@ -8,7 +8,6 @@
 from openstax_accounts.interfaces import IOpenstaxAccountsAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.config import Configurator
-from pyramid.security import Allow, Everyone, Authenticated
 from pyramid.session import SignedCookieSessionFactory
 
 
@@ -75,7 +74,7 @@ def main(global_config, **settings):
     config.include('openstax_accounts')
     # authorization policy must be set if an authentication policy is set
     config.set_authentication_policy(
-            config.registry.getUtility(IOpenstaxAccountsAuthenticationPolicy))
+        config.registry.getUtility(IOpenstaxAccountsAuthenticationPolicy))
     config.set_authorization_policy(ACLAuthorizationPolicy())
 
     return config.make_wsgi_app()

--- a/cnxauthoring/__init__.py
+++ b/cnxauthoring/__init__.py
@@ -15,9 +15,9 @@ def declare_routes(config):
     """Declaration of routing"""
     add_route = config.add_route
     add_route('options',
-              '/{foo:(\*|search|contents|users|resources|login|callback|logout)/?.*}',  # noqa
+              '/{foo:(\*|contents|users|resources|login|callback|logout)/?.*}',  # noqa
               request_method='OPTIONS')
-    add_route('search-content', '/search', request_method='GET')
+    add_route('search-content', '/users/contents/search', request_method='GET')
     add_route('get-content-json', '/contents/{id}@draft.json',
               request_method='GET')
     add_route('get-resource', '/resources/{hash}', request_method='GET')


### PR DESCRIPTION
authoring has a search API, but because both authoring and webview are deployed to the toplevel server, there is a collision on what /search means. This moves authoring search to /users/contents/search 