### PR TITLE
Use cnxepub.DocumentContentFormatter instead of cnxepub.Document.html

### DIFF
--- a/cnxauthoring/utils.py
+++ b/cnxauthoring/utils.py
@@ -223,7 +223,8 @@ def derive_resources(request, document):
                                             io.BytesIO(response.content))
                 yield resources[r.uri]
             r.bind(resources[r.uri], path)
-    document.metadata['content'] = document.html
+    html = cnxepub.DocumentContentFormatter(document)
+    document.metadata['content'] = str(html)
 
 
 def profile_to_user_dict(profile):


### PR DESCRIPTION
Please remove the last commit which changes .travis.yml before merging.

Depends on https://github.com/Connexions/cnx-epub/pull/51