### PR TITLE
Add postgres host and port to testing configuration

### DIFF
--- a/cnxauthoring/tests/pub_n_arc.ini
+++ b/cnxauthoring/tests/pub_n_arc.ini
@@ -1,7 +1,7 @@
 [app:main]
 use = egg:cnx-publishing
 ##use = egg:cnx-archive
-db-connection-string = dbname=cnxarchive-testing user=cnxarchive password=cnxarchive
+db-connection-string = dbname=cnxarchive-testing user=cnxarchive password=cnxarchive host=localhost port=5432
 
 # Authentication
 api-key-authnz =

--- a/cnxauthoring/tests/testing.ini
+++ b/cnxauthoring/tests/testing.ini
@@ -10,7 +10,7 @@ cors.access_control_allow_origin = http://localhost:8000 http://localhost:9000
 cors.access_control_allow_headers = Origin, Content-Type
 cors.access_control_allow_methods = GET, OPTIONS, PUT, POST
 
-postgresql.db-connection-string = dbname=authoring-test user=cnxauthoring password=cnxauthoring
+postgresql.db-connection-string = dbname=authoring-test user=cnxauthoring password=cnxauthoring host=localhost port=5432
 default-license-url = http://creativecommons.org/licenses/by/4.0/
 current-license-urls =
    http://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
Fixes the testing configuration to include the host and port to the postgresql service. This change brings the testing configuration inline with similar changes done in cnx-archive and cnx-publishing.