### PR TITLE
Keep draft on non success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,11 +52,6 @@ before_install:
   - pip install coverage
   - pip install coveralls
 
-  # Uninstall mock to fix error
-  # VersionConflict: (mock 1.3.0 ... Requirement.parse('mock==1.0.1'))
-  # (See Pull Request #241, Travis Build #1088)
-  - pip uninstall -y mock
-
 install:
   - python setup.py install
   - cnx-authoring-initialize_db cnxauthoring/tests/testing.ini

--- a/cnxauthoring/tests/intercept.py
+++ b/cnxauthoring/tests/intercept.py
@@ -21,9 +21,8 @@ from wsgi_intercept import (
     )
 
 from cnxarchive import config
-from cnxarchive.database import initdb as archive_initdb
 from cnxarchive import main as archive_main
-from cnxpublishing.db import initdb as publishing_initdb
+from cnxdb.init import init_db
 from cnxpublishing.main import main as publishing_main
 
 from .testing import integration_test_settings
@@ -80,7 +79,8 @@ def _amend_archive_data():
 INSERT INTO api_keys (key, name, groups) VALUES
   ('b07', 'trusted', '{"g:trusted-publishers"}');
 INSERT INTO document_controls (uuid, licenseid) VALUES
-  ('a3f7c934-2a89-4baf-a9a9-a89d957586d2', 11);
+  ('a3f7c934-2a89-4baf-a9a9-a89d957586d2', 11),
+  ('174c4069-2743-42e9-adfe-4c7084f81fc5', 11);
 INSERT INTO abstracts (abstractid, abstract, html) VALUES
   (9000, '', '');
 INSERT INTO modules
@@ -191,10 +191,8 @@ def install_intercept():
         with db_connection.cursor() as cursor:
             cursor.execute("DROP SCHEMA public CASCADE; CREATE SCHEMA public")
 
-    # Initialize the archive database.
-    archive_initdb(settings)
-    # Initialize the publishing database.
-    publishing_initdb(connection_string)
+    # Initialize the database.
+    init_db(connection_string, True)
     with psycopg2.connect(connection_string) as db_connection:
         with db_connection.cursor() as cursor:
             filepath = config.TEST_DATA_SQL_FILE

--- a/cnxauthoring/tests/pub_n_arc.ini
+++ b/cnxauthoring/tests/pub_n_arc.ini
@@ -1,7 +1,7 @@
 [app:main]
 use = egg:cnx-publishing
 ##use = egg:cnx-archive
-db-connection-string = dbname=cnxarchive-testing user=cnxarchive password=cnxarchive host=localhost port=5432
+db-connection-string = dbname=cnxarchive-testing user=cnxarchive password=cnxarchive
 
 # Authentication
 api-key-authnz =
@@ -41,6 +41,7 @@ exports-allowable-types =
     pdf:pdf,application/pdf,PDF,PDF file, for viewing content offline and printing.
     epub:epub,application/epub+zip,EPUB,Electronic book format file, for viewing on mobile devices.
     zip:zip,application/zip,Offline ZIP,An offline HTML copy of the content.  Also includes XML, included media files, and other support files.
+sitemap-destination = http://cnx.org/sitemap.xml
 
 
 # ---

--- a/cnxauthoring/tests/test_functional.py
+++ b/cnxauthoring/tests/test_functional.py
@@ -35,7 +35,7 @@ from wsgi_intercept import requests_intercept
 
 from .intercept import (install_intercept, uninstall_intercept,
                         publishing_settings)
-from .testing import integration_test_settings, test_data
+from .testing import integration_test_settings, get_data
 from ..models import DEFAULT_LICENSE, TZINFO
 
 
@@ -514,7 +514,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'derivedFromUri': u'http://cnx.org/contents/{}@1'.format(
                 post_data['derivedFrom']),
             u'title': u'Copy of Indkøb',
-            u'abstract': u'',
+            u'abstract': u'<div xmlns="http://www.w3.org/1999/xhtml">foo</div>',
             u'language': u'da',
             u'mediaType': u'application/vnd.org.cnx.module',
             u'version': u'draft',
@@ -565,7 +565,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'derivedFromUri': u'http://cnx.org/contents/{}@1'.format(
                 post_data['derivedFrom']),
             u'title': u'Copy of Indkøb',
-            u'abstract': u'',
+            u'abstract': u'<div xmlns="http://www.w3.org/1999/xhtml">foo</div>',
             u'language': u'da',
             u'mediaType': u'application/vnd.org.cnx.module',
             u'version': u'draft',
@@ -635,7 +635,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'derivedFromUri': u'http://cnx.org/contents/{}'.format(
                 post_data['derivedFrom']),
             u'title': u'Copy of Indkøb',
-            u'abstract': u'',
+            u'abstract': u'<div xmlns="http://www.w3.org/1999/xhtml">foo</div>',
             u'language': u'da',
             u'mediaType': u'application/vnd.org.cnx.module',
             u'version': u'draft',
@@ -686,7 +686,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'derivedFromUri': u'http://cnx.org/contents/{}'.format(
                 post_data['derivedFrom']),
             u'title': u'Copy of Indkøb',
-            u'abstract': u'',
+            u'abstract': u'<div xmlns="http://www.w3.org/1999/xhtml">foo</div>',
             u'language': u'da',
             u'mediaType': u'application/vnd.org.cnx.module',
             u'version': u'draft',
@@ -862,10 +862,10 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'publishers': [submitter_w_assign_date],
             u'id': result['id'],
             u'derivedFrom': post_data['derivedFrom'],
-            u'derivedFromTitle': u'Derived Copy of College Physics',
+            u'derivedFromTitle': u'<span style="color:red;">Derived</span> Copy of College <i>Physics</i>',
             u'derivedFromUri': u'http://cnx.org/contents/{}'.format(
                 post_data['derivedFrom']),
-            u'title': u'Copy of Derived Copy of College Physics',
+            u'title': u'Copy of <span style="color:red;">Derived</span> Copy of College <i>Physics</i>',
             u'content': u'',
             u'language': u'en',
             u'mediaType': u'application/vnd.org.cnx.collection',
@@ -897,13 +897,13 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'subjects': [],
             u'tree': {
                 u'id': u'{}@draft'.format(result['id']),
-                u'title': u'Copy of Derived Copy of College Physics',
+                u'title': u'Copy of <span style="color:red;">Derived</span> Copy of College <i>Physics</i>',
                 u'isPublishable': True,
                 u'publishBlockers': None,
                 u'contents': [
                     {u'id': u'209deb1f-1a46-4369-9e0d-18674cf58a3e@7',
                      u'title': u'Preface'},
-                    {u'id': u'subcol',
+                    {u'id': u'8a11a2f3-0099-55ef-87bf-9725214fcd8a@1.1',
                      u'title': u'Introduction: The Nature of Science and Physics',
                      u'contents': [
                          {u'id': u'f3c9ab70-a916-4d8c-9256-42953287b4e9@3',
@@ -916,7 +916,7 @@ class FunctionalTests(BaseFunctionalTestCase):
                           u'title': u'Accuracy, Precision, and Significant Figures'},
                          {u'id': u'5838b105-41cd-4c3d-a957-3ac004a48af3@5',
                           u'title': u'Approximation'}]},
-                    {u'id': u'subcol',
+                    {u'id': u'd8bd3fb3-7b7b-5cee-9f2d-839e76638459@1.1',
                      u'title': u"Further Applications of Newton's Laws: Friction, Drag, and Elasticity",
                      u'contents': [
                          {u'id': u'24a2ed13-22a6-47d6-97a3-c8aa8d54ac6d@2',
@@ -1599,7 +1599,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'publishers': [submitter_w_assign_date],
             u'id': binder['id'],
             u'derivedFrom': post_data['derivedFrom'],
-            u'derivedFromTitle': u'Derived Copy of College Physics',
+            u'derivedFromTitle': u'<span style="color:red;">Derived</span> Copy of College <i>Physics</i>',
             u'derivedFromUri': u'http://cnx.org/contents/{}'.format(
                 post_data['derivedFrom']),
             u'abstract': u'...',
@@ -1659,7 +1659,7 @@ class FunctionalTests(BaseFunctionalTestCase):
             u'publishers': [submitter_w_assign_date],
             u'id': binder['id'],
             u'derivedFrom': post_data['derivedFrom'],
-            u'derivedFromTitle': u'Derived Copy of College Physics',
+            u'derivedFromTitle': u'<span style="color:red;">Derived</span> Copy of College <i>Physics</i>',
             u'derivedFromUri': u'http://cnx.org/contents/{}'.format(
                 post_data['derivedFrom']),
             u'abstract': u'...',
@@ -2364,7 +2364,7 @@ class FunctionalTests(BaseFunctionalTestCase):
         self.assert_cors_headers(response)
 
     def test_get_resource_403(self):
-        with open(test_data('1x1.png'), 'rb') as data:
+        with open(get_data('1x1.png'), 'rb') as data:
             upload_data = data.read()
 
         response = self.testapp.post(
@@ -2402,7 +2402,7 @@ class FunctionalTests(BaseFunctionalTestCase):
         self.assert_cors_headers(response)
 
     def test_get_resource(self):
-        with open(test_data('1x1.png'), 'rb') as data:
+        with open(get_data('1x1.png'), 'rb') as data:
             upload_data = data.read()
 
         response = self.testapp.post(
@@ -3134,7 +3134,7 @@ class FunctionalTests(BaseFunctionalTestCase):
         self.assertEqual(response.status, '503 Service Unavailable')
 
     @mock.patch('cnxauthoring.views.logger')
-    def test_database_restart_failed(self, logger):
+    def get_database_restart_failed(self, logger):
         import psycopg2
         from ..storage import storage
 
@@ -3275,6 +3275,7 @@ class PublicationTests(BaseFunctionalTestCase):
             'title': u'Página dos',
             'content': (u'<html><body><p>Contents of Página dos</p></body>'
                         u'</html>'),
+            'abstract': 'Hola!',
             'language': 'es',
             }
         response = self.testapp.post_json(
@@ -3349,7 +3350,8 @@ class PublicationTests(BaseFunctionalTestCase):
 
         response = self.testapp.post_json('/users/contents', {
             'title': 'Page two',
-            'content': '<html><body><p>Content of page two</p></body></html>'
+            'content': '<html><body><p>Content of page two</p></body></html>',
+            'abstract': 'gotta have one'
             }, status=201)
         page2 = response.json
         self.assert_cors_headers(response)
@@ -3461,7 +3463,8 @@ class PublicationTests(BaseFunctionalTestCase):
         response = self.testapp.post_json('/users/contents', {
             'title': 'Page two',
             'content': '<html><body><p>Content of page two</p></body></html>',
-            'printStyle': '[PDF Print Style]'
+            'printStyle': '[PDF Print Style]',
+            'abstract': 'need one'
             }, status=201)
         page2 = response.json
         self.assert_cors_headers(response)

--- a/cnxauthoring/tests/test_storage/test_postgresql.py
+++ b/cnxauthoring/tests/test_storage/test_postgresql.py
@@ -9,7 +9,7 @@ import io
 import unittest
 import uuid
 
-from .. import test_data
+from .. import get_data
 from ...models import Document, Resource, Binder
 from ..testing import integration_test_settings
 
@@ -114,7 +114,7 @@ class PostgresqlStorageTests(unittest.TestCase):
         self.assertEqual(result, None)
 
     def test_add_get_and_remove_resource(self):
-        with open(test_data('1x1.png'), 'rb') as f:
+        with open(get_data('1x1.png'), 'rb') as f:
             data = f.read()
         r = Resource('image/png', io.BytesIO(data))
         self.storage.add(r)

--- a/cnxauthoring/tests/test_views.py
+++ b/cnxauthoring/tests/test_views.py
@@ -171,7 +171,7 @@ class ViewsTests(unittest.TestCase):
 
     def test_get_content_for_document(self):
         # Set up a piece of content.
-        id = uuid.uuid4(),
+        id = str(uuid.uuid4()),
         document_title = "The Floating Dust"
         from ..models import Document
         expected = Document(document_title, id=id)
@@ -229,7 +229,7 @@ class ViewsTests(unittest.TestCase):
         def mocked_add(item):
             self.document = item
             self.document.acls = {'userid': ('edit', 'publish', 'view')}
-            self.document.id = uuid.uuid4()
+            self.document.id = str(uuid.uuid4())
             return self.document
         # Given the minimal amount of information, create a document.
         self.storage_cls.add = mock.Mock(side_effect=mocked_add)
@@ -264,7 +264,7 @@ class ViewsTests(unittest.TestCase):
         def mocked_add(item):
             self.document = item
             self.document.acls = {'username': ('edit', 'publish', 'view')}
-            self.document.id = uuid.uuid4()
+            self.document.id = str(uuid.uuid4())
             return self.document
         self.storage_cls.add = mock.Mock(side_effect=mocked_add)
         self.storage_cls.persist = mock.Mock(return_value=None)

--- a/cnxauthoring/tests/testing.py
+++ b/cnxauthoring/tests/testing.py
@@ -12,7 +12,7 @@ from pyramid.paster import get_appsettings
 
 __all__ = (
     'TEST_DATA_DIRECTORY',
-    'integration_test_settings', 'set_up_licenses', 'test_data',
+    'integration_test_settings', 'set_up_licenses', 'get_data',
     )
 
 
@@ -25,7 +25,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 TEST_DATA_DIRECTORY = os.path.join(here, 'data')
 
 
-def test_data(filename):
+def get_data(filename):
     """Get the path to a test data file."""
     return os.path.join(TEST_DATA_DIRECTORY, filename)
 

--- a/cnxauthoring/utils.py
+++ b/cnxauthoring/utils.py
@@ -186,7 +186,8 @@ def fetch_archive_content(request, archive_id, extras=False):
             archive_url, '/extras/{}'.format(archive_id))
     else:
         content_url = urlparse.urljoin(
-            archive_url, '/contents/{}.json'.format(archive_id))
+            archive_url, '/contents/{}.json?as_collated=false'.format(
+                archive_id))
     try:
         response = requests.get(content_url)
     except requests.exceptions.ConnectionError as exc:

--- a/setup.py
+++ b/setup.py
@@ -18,15 +18,8 @@ install_requires = (
 tests_require = (
         'cnx-archive',
         'cnx-publishing',
-        # FIXME httpretty 0.8.11 is broken:
-        # File ".../httpretty/setup.py", line 98, in <module>
-        #   tests_require=parse_requirements('development.txt'),
-        # File ".../httpretty/setup.py", line 62, in parse_requirements
-        #   raise RuntimeError("Couldn't find the `requirements.txt' file :(")
-        'HTTPretty==0.8.10',
-        # FIXME mock>1.1 uses setuptools>17.1 which is not available
-        #       in debian/ubuntu stable.
-        'mock==1.0.1',   # only required for python2
+        'HTTPretty',
+        'mock',   # only required for python2
         'WebTest',
         'wsgi_intercept',
         )


### PR DESCRIPTION
If cnx-publishing responds with anything other than success, don't increment the local version number. This allows a simple retry of publishing, after correcting the problem.

depends on Connexions/cnx-archive#481